### PR TITLE
fixed payment type info

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Fixed bug where /views/paymenttype.py expiration_date and create_date were not on the correct lines




- [ ] git fetch --all
- [ ] git checkout bk-paymentTypeInfo
- [ ] Perform a POST request in postman to make sure the expiration_date and create_date is correct. use this url 'http://localhost:8000/paymenttypes' should return:

 {
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/4",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi2",
        "expiration_date": "2021-02-01",
        "create_date": "2019-12-12"
    }




- Fixes #19 